### PR TITLE
Add settings dialog and improve URL bar behavior

### DIFF
--- a/Cryptidium.vcxproj
+++ b/Cryptidium.vcxproj
@@ -75,8 +75,10 @@
     <ClCompile Include="Cryptidium.cpp" />
     <ClCompile Include="buildinfo.cpp" />
     <ClCompile Include="gui.cpp" />
+    <ClCompile Include="settings.cpp" />
     <ClInclude Include="buildinfo.h" />
     <ClInclude Include="gui.h" />
+    <ClInclude Include="settings.h" />
     <None Include="assets\app.ico" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,0 +1,66 @@
+#include "settings.h"
+#include <WebKit/WebKit2_C.h>
+#include "buildinfo.h"
+
+static void ClearCookies() {
+    WKWebsiteDataStoreRef store = WKWebsiteDataStoreGetDefaultDataStore();
+    WKMutableArrayRef types = WKMutableArrayCreate();
+    WKArrayAppendItem(types, WKWebsiteDataTypeCookies());
+    WKWebsiteDataStoreRemoveDataOfTypes(store, types, 0, nullptr, nullptr);
+    WKRelease(types);
+}
+
+static void ClearCache() {
+    WKWebsiteDataStoreRef store = WKWebsiteDataStoreGetDefaultDataStore();
+    WKMutableArrayRef types = WKMutableArrayCreate();
+    WKArrayAppendItem(types, WKWebsiteDataTypeDiskCache());
+    WKArrayAppendItem(types, WKWebsiteDataTypeMemoryCache());
+    WKWebsiteDataStoreRemoveDataOfTypes(store, types, 0, nullptr, nullptr);
+    WKRelease(types);
+}
+
+static LRESULT CALLBACK SettingsWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+    case WM_CREATE: {
+        wchar_t ver[64];
+        wsprintfW(ver, L"Version: %s", BuildInfo::kVersionFormatted);
+        CreateWindowW(L"STATIC", ver, WS_CHILD | WS_VISIBLE, 10, 10, 250, 20, hwnd, nullptr, nullptr, nullptr);
+        CreateWindowW(L"BUTTON", L"Clear Cookies", WS_CHILD | WS_VISIBLE, 10, 40, 110, 24, hwnd, (HMENU)2001, nullptr, nullptr);
+        CreateWindowW(L"BUTTON", L"Clear Cache", WS_CHILD | WS_VISIBLE, 130, 40, 110, 24, hwnd, (HMENU)2002, nullptr, nullptr);
+        return 0;
+    }
+    case WM_COMMAND:
+        switch (LOWORD(wParam)) {
+        case 2001:
+            ClearCookies();
+            MessageBoxW(hwnd, L"Cookies cleared.", L"Settings", MB_OK);
+            break;
+        case 2002:
+            ClearCache();
+            MessageBoxW(hwnd, L"Cache cleared.", L"Settings", MB_OK);
+            break;
+        }
+        return 0;
+    case WM_CLOSE:
+        DestroyWindow(hwnd);
+        return 0;
+    }
+    return DefWindowProc(hwnd, msg, wParam, lParam);
+}
+
+void ShowSettings(HWND parent) {
+    static bool registered = false;
+    static const wchar_t CLASS_NAME[] = L"SettingsWindow";
+    if (!registered) {
+        WNDCLASSW wc{};
+        wc.lpfnWndProc = SettingsWndProc;
+        wc.hInstance = GetModuleHandleW(nullptr);
+        wc.lpszClassName = CLASS_NAME;
+        RegisterClassW(&wc);
+        registered = true;
+    }
+    HWND wnd = CreateWindowW(CLASS_NAME, L"Settings", WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU,
+                             CW_USEDEFAULT, CW_USEDEFAULT, 260, 120, parent, nullptr, nullptr, nullptr);
+    ShowWindow(wnd, SW_SHOW);
+}
+

--- a/settings.h
+++ b/settings.h
@@ -1,0 +1,3 @@
+#pragma once
+#include <windows.h>
+void ShowSettings(HWND parent);


### PR DESCRIPTION
## Summary
- add settings dialog with version info and buttons to clear cookies or cache
- enhance URL bar: load only on Enter, auto-prefix https, google search for spaced queries, and update after navigation
- move settings dialog logic into dedicated source and header files

## Testing
- `g++ -std=c++17 -c gui.cpp settings.cpp` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_688e28274bd88332b0f9bbe8cddc4c3a