### PR TITLE
Fix close tab button not working

### DIFF
--- a/gui.cpp
+++ b/gui.cpp
@@ -200,7 +200,7 @@ static void AddTab(HWND hWnd, const char* url)
     int img = ImageList_AddIcon(gTabImages, ph);
     DestroyIcon(ph);
     HWND closeBtn = CreateWindowW(L"BUTTON", L"x", WS_CHILD | WS_VISIBLE,
-                                  0, 0, 16, 16, gTabCtrl, nullptr, nullptr, nullptr);
+                                  0, 0, 16, 16, hWnd, nullptr, nullptr, nullptr);
     SendMessageW(closeBtn, WM_SETFONT, (WPARAM)gUIFont, TRUE);
     gTabs.push_back({ view, closeBtn, img });
     int index = static_cast<int>(gTabs.size()) - 1;
@@ -229,15 +229,18 @@ static void CloseTab(HWND hWnd, int index)
     WKRelease(view);
     gTabs.erase(gTabs.begin() + index);
     TabCtrl_DeleteItem(gTabCtrl, index);
+    if (gTabs.empty()) {
+        PostMessageW(hWnd, WM_CLOSE, 0, 0);
+        return;
+    }
     if (gCurrentTab >= index)
         gCurrentTab--;
-    if (gCurrentTab >= 0) {
-        ShowCurrentTab();
-        TabCtrl_SetCurSel(gTabCtrl, gCurrentTab);
+    ShowCurrentTab();
+    TabCtrl_SetCurSel(gTabCtrl, gCurrentTab);
+    if (gCurrentTab >= 0)
         UpdateUrlBarFromPage(WKViewGetPage(gTabs[gCurrentTab].view));
-    } else {
+    else
         SetWindowTextW(gUrlBar, L"");
-    }
     ResizeChildren(hWnd);
 }
 


### PR DESCRIPTION
## Summary
- Fix close-tab button by reparenting it to the main window so clicks trigger WM_COMMAND
- Close the application when the last tab is closed

## Testing
- `x86_64-w64-mingw32-g++ -c gui.cpp` *(fails: fatal error: WebKit/WebKit2_C.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_688e3df944d48332a5aadfe2d1a1c84f