### PR TITLE
Handle file and mouse navigation

### DIFF
--- a/Cryptidium.cpp
+++ b/Cryptidium.cpp
@@ -1,6 +1,34 @@
 #include <windows.h>
+#include <shellapi.h>
+#include <string>
 #include "gui.h"
 
 int WINAPI wWinMain(HINSTANCE hInst, HINSTANCE, PWSTR, int nCmdShow) {
-    return RunBrowser(hInst, nCmdShow);
+    int argc = 0;
+    LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+    std::string url;
+    const char* initial = nullptr;
+    if (argv && argc > 1) {
+        std::wstring arg = argv[1];
+        if (arg.rfind(L"https://", 0) == 0) {
+            int len = WideCharToMultiByte(CP_UTF8, 0, arg.c_str(), -1, nullptr, 0, nullptr, nullptr);
+            url.resize(len - 1);
+            WideCharToMultiByte(CP_UTF8, 0, arg.c_str(), -1, url.data(), len, nullptr, nullptr);
+        } else {
+            wchar_t full[MAX_PATH];
+            if (GetFullPathNameW(arg.c_str(), MAX_PATH, full, nullptr)) {
+                int len = WideCharToMultiByte(CP_UTF8, 0, full, -1, nullptr, 0, nullptr, nullptr);
+                std::string tmp(len - 1);
+                WideCharToMultiByte(CP_UTF8, 0, full, -1, tmp.data(), len, nullptr, nullptr);
+                for (char& c : tmp)
+                    if (c == '\\')
+                        c = '/';
+                url = "file:///" + tmp;
+            }
+        }
+        initial = url.c_str();
+    }
+    if (argv)
+        LocalFree(argv);
+    return RunBrowser(hInst, nCmdShow, initial);
 }

--- a/gui.h
+++ b/gui.h
@@ -2,6 +2,6 @@
 #include <windows.h>
 #include <WebKit/WebKit2_C.h>
 
-int RunBrowser(HINSTANCE hInstance, int nCmdShow);
+int RunBrowser(HINSTANCE hInstance, int nCmdShow, const char* initialUrl = nullptr);
 WKContextRef GetCurrentContext();
 HFONT GetUIFont();


### PR DESCRIPTION
## Summary
- Allow browser to open files and HTTPS/PDF links via command-line argument
- Support mouse forward/back buttons for history navigation

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_688f39049f208332abb880e79fe870f7